### PR TITLE
Filter string shenanigans

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -53,6 +53,24 @@
 
   </Description>
   <!-- Ingame Description using TMP tags for Workshop menu -->
+
+  <!-- All contents of ChangeLog should be changed for each publication for Steam workshop page -->
+  <ChangeLog>
+    [h3]Version 0.1.0000.00000.0:[/h3]
+    [list]
+    [*]Initial release
+    [/list]
+  </ChangeLog>
+  <WorkshopHandle>3315641641</WorkshopHandle>
+  <!-- StationeersMods and BepInEx tags for Steam workshop page will be automatically added by the framework when publishing -->
+  <Tags>
+    <Tag>StationeersMods</Tag>
+  </Tags>
+  <!-- Automatic downloads of dependencies -->
+  <Dependencies />
+  <!-- Automatic reordering of the mods list -->
+  <LoadBefore />
+  <LoadAfter />
   <InGameDescription>
     <![CDATA[<size="30"><color=#ffa500> MoreGasDisplayConsoleOptions </color></size>
 <b>WARNING:</b> <color=#ff0000>This is a StationeersMods Plugin Mod. It requires Bepinex to be installed with the StationeersMods plugin.</color>
@@ -95,20 +113,4 @@ List of modes:
     * Liquid volume
 ]]>
   </InGameDescription>
-  <!-- All contents of ChangeLog should be changed for each publication for Steam workshop page -->
-  <ChangeLog>
-    [h3]Version 0.1.0000.00000.0:[/h3]
-    [list]
-    [*]Initial release
-    [/list]
-  </ChangeLog>
-  <!-- StationeersMods and BepInEx tags for Steam workshop page will be automatically added by the framework when publishing -->
-  <Tags>
-    <Tag>StationeersMods</Tag>
-  </Tags>
-  <!-- Automatic downloads of dependencies -->
-  <Dependencies />
-  <!-- Automatic reordering of the mods list -->
-  <LoadBefore />
-  <LoadAfter />
 </ModMetadata>

--- a/About/About.xml
+++ b/About/About.xml
@@ -52,53 +52,53 @@
     [*] "GO2P"   - Gaseous O2 Ratio
     [*] "GO2M"   - Gaseous O2 Moles
     [*] "LO2P"   - Liquid O2 Ratio
-    [*] "LO2V"   - Liquid O2 Volume
     [*] "LO2M"   - Liquid O2 Moles
+    [*] "LO2V"   - Liquid O2 Volume
     [*] "NP"     - N Ratio
     [*] "NM"     - N Moles
     [*] "NP"     - Gaseous N Ratio
-    [*] "GNM"    - Gaseous N Mole
+    [*] "GNM"    - Gaseous N Moles
     [*] "LNP"    - Liquid N Ratio
-    [*] "LNV"    - Liquid N Volum
     [*] "LNM"    - Liquid N Moles
+    [*] "LNV"    - Liquid N Volume
     [*] "CO2P"   - CO2 Ratio
     [*] "CO2M"   - CO2 Moles
     [*] "GCO2P"  - Gaseous CO2 Ratio
-    [*] "GCO2M"  - Gaseous CO2 Mole
+    [*] "GCO2M"  - Gaseous CO2 Moles
     [*] "LCO2P"  - Liquid CO2 Ratio
-    [*] "LCO2V"  - Liquid CO2 Volum
     [*] "LCO2M"  - Liquid CO2 Moles
+    [*] "LCO2V"  - Liquid CO2 Volume
     [*] "POLP"   - POL Ratio
     [*] "POLM"   - POL Moles
     [*] "GPOLP"  - Gaseous POL Ratio
-    [*] "GPOLM"  - Gaseous POL Mole
+    [*] "GPOLM"  - Gaseous POL Moles
     [*] "LPOLP"  - Liquid POL Ratio
-    [*] "LPOLV"  - Liquid POL Volum
     [*] "LPOLM"  - Liquid POL Moles
+    [*] "LPOLV"  - Liquid POL Volume
     [*] "VOLP"   - VOL Ratio
     [*] "VOLM"   - VOL Moles
     [*] "GVOLP"  - Gaseous VOL Ratio
-    [*] "GVOLM"  - Gaseous VOL Mole
+    [*] "GVOLM"  - Gaseous VOL Moles
     [*] "LVOLP"  - Liquid VOL Ratio
-    [*] "LVOLV"  - Liquid VOL Volum
     [*] "LVOLM"  - Liquid VOL Moles
+    [*] "LVOLV"  - Liquid VOL Volume
     [*] "N2OP"   - N2O Ratio
     [*] "N2OM"   - N2O Moles
     [*] "GN2OP"  - Gaseous N2O Ratio
-    [*] "GN2OM"  - Gaseous N2O Mole
+    [*] "GN2OM"  - Gaseous N2O Moles
     [*] "LN2OP"  - Liquid N2O Ratio
-    [*] "LN2OV"  - Liquid N2O Volum
     [*] "LN2OM"  - Liquid N2O Moles
+    [*] "LN2OV"  - Liquid N2O Volume
     [*] "H2OP "  - H2O Ratio
     [*] "H2OM "  - H2O Moles
     [*] "GH2OP"  - Steam H2O Ratio
-    [*] "GH2OM"  - Steam H2O Mole
+    [*] "GH2OM"  - Steam H2O Moles
     [*] "LH2OP"  - Water Ratio
-    [*] "LH2OV"  - Water Volum
     [*] "LH2OM"  - Water Moles
+    [*] "LH2OV"  - Water Volume
     [*] "LPH2OP" - Polluted Water Ratio
-    [*] "LPH2OV" - Polluted Water Volum
     [*] "LPH2OM" - Polluted Water Moles
+    [*] "LPH2OV" - Polluted Water Volume
     [*] "P"      - Vanilla Pressure
     [/olist]
 

--- a/About/About.xml
+++ b/About/About.xml
@@ -2,7 +2,7 @@
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>MoreGasDisplayConsoleOptions [StationeersMods]</Name>
   <Author>Vespinian</Author>
-  <Version>0.1.0000.00001.0</Version>
+  <Version>0.1.0000.00002.0</Version>
   <!-- Steam description using steam styling tags for Steam workshop page -->
   <Description>
     [h1]MoreGasDisplayConsoleOptions[/h1]
@@ -11,8 +11,12 @@
 
     [b]WARNING:[/b] This mod is incompatible with my KelvinConsole mod so make sure you disable/unsubscribe it if you have it installed.
 
-    This mod adds a bunch of modes to the gas display consoles which coverts pretty much everything the atmospheric analyzer from the tablet gives you.
-    There's 62 modes in total so have fun clicking!
+    This mod adds a bunch of modes to the gas display consoles which covers pretty much everything the atmospheric analyzer from the tablet gives you.
+    There's 63 modes in total so have fun clicking!
+    You can use the quantity modifier to backtrack.
+    You can also use the filter function of the console to target specific modes or at least get closer to the one you want.
+    To use the mod's filter function you will need to hold Left Alt when clicking the confirm button in the filter input menu.
+    The filter first checks if you inputted a tag, if it gets no match it tries to match your input to one of the display titles.
 
     Source: https://github.com/Vespinian/stationeers-mgdco
 
@@ -26,29 +30,71 @@
     [*] Energy values are additive.
     [/list]
 
-    List of modes:
-    General Modes:
+    List of tags and modes:
     [list]
-    [*] Pressure
-    [*] Temperature Celcius
-    [*] Temperature Kelvin
-    [*] Total moles
-    [*] Total gaseous moles
-    [*] Total liquid moles
-    [*] Total liquid volume
-    [*] Convected energy
-    [*] Radation energy
-    [*] Latent energy
-    [/list]
-    For every gas:
-    [list]
-    [*] Total moles
-    [*] Mole ratio
-    [*] Gaseous moles
-    [*] Gaseous mole ratio
-    [*] Liquid moles
-    [*] Liquid mole ratio
-    [*] Liquid volume
+    [*] "P"      - Vanilla Pressure
+    [*] "PP"     - Precise Pressure
+    [*] "TC"     - Temperature Celcius
+    [*] "TK"     - Temperature Kelvin
+    [*] "M",     - Total Moles
+    [*] "GM"     - Gaseous Moles
+    [*] "LM"     - Liquid Moles
+    [*] "LV"     - Liquid Volume
+    [*] "EC"     - Energy Convected
+    [*] "ER"     - Energy Radiated
+    [*] "EL"     - Energy Latent
+    [*] "O2P"    - O2 Ratio
+    [*] "O2M"    - O2 Moles
+    [*] "GO2P"   - Gaseous O2 Ratio
+    [*] "GO2M"   - Gaseous O2 Moles
+    [*] "LO2P"   - Liquid O2 Ratio
+    [*] "LO2V"   - Liquid O2 Volume
+    [*] "LO2M"   - Liquid O2 Moles
+    [*] "NP"     - N Ratio
+    [*] "NM"     - N Moles
+    [*] "NP"     - Gaseous N Ratio
+    [*] "GNM"    - Gaseous N Mole
+    [*] "LNP"    - Liquid N Ratio
+    [*] "LNV"    - Liquid N Volum
+    [*] "LNM"    - Liquid N Moles
+    [*] "CO2P"   - CO2 Ratio
+    [*] "CO2M"   - CO2 Moles
+    [*] "GCO2P"  - Gaseous CO2 Ratio
+    [*] "GCO2M"  - Gaseous CO2 Mole
+    [*] "LCO2P"  - Liquid CO2 Ratio
+    [*] "LCO2V"  - Liquid CO2 Volum
+    [*] "LCO2M"  - Liquid CO2 Moles
+    [*] "POLP"   - POL Ratio
+    [*] "POLM"   - POL Moles
+    [*] "GPOLP"  - Gaseous POL Ratio
+    [*] "GPOLM"  - Gaseous POL Mole
+    [*] "LPOLP"  - Liquid POL Ratio
+    [*] "LPOLV"  - Liquid POL Volum
+    [*] "LPOLM"  - Liquid POL Moles
+    [*] "VOLP"   - VOL Ratio
+    [*] "VOLM"   - VOL Moles
+    [*] "GVOLP"  - Gaseous VOL Ratio
+    [*] "GVOLM"  - Gaseous VOL Mole
+    [*] "LVOLP"  - Liquid VOL Ratio
+    [*] "LVOLV"  - Liquid VOL Volum
+    [*] "LVOLM"  - Liquid VOL Moles
+    [*] "N2OP"   - N2O Ratio
+    [*] "N2OM"   - N2O Moles
+    [*] "GN2OP"  - Gaseous N2O Ratio
+    [*] "GN2OM"  - Gaseous N2O Mole
+    [*] "LN2OP"  - Liquid N2O Ratio
+    [*] "LN2OV"  - Liquid N2O Volum
+    [*] "LN2OM"  - Liquid N2O Moles
+    [*] "H2OP "  - H2O Ratio
+    [*] "H2OM "  - H2O Moles
+    [*] "GH2OP"  - Steam H2O Ratio
+    [*] "GH2OM"  - Steam H2O Mole
+    [*] "LH2OP"  - Water Ratio
+    [*] "LH2OV"  - Water Volum
+    [*] "LH2OM"  - Water Moles
+    [*] "LPH2OP" - Polluted Water Ratio
+    [*] "LPH2OV" - Polluted Water Volum
+    [*] "LPH2OM" - Polluted Water Moles
     [/list]
 
   </Description>
@@ -56,7 +102,13 @@
 
   <!-- All contents of ChangeLog should be changed for each publication for Steam workshop page -->
   <ChangeLog>
-    [h3]Version 0.1.0000.00000.0:[/h3]
+    [h3]Version 0.1.0000.00002.0:[/h3]
+    [list]
+    [*]Can now use the quantity modifier key to cycle through mods backwards
+    [*]Can now use the filter function to target certain modes when holding left alt when clicking the Confirm button in the filter input menu.
+    [*]Added back old pressure format function to as Pressure, my new formatting is now known as Prescise Pressure.
+    [/list]
+    [h3]Version 0.1.0000.00001.0:[/h3]
     [list]
     [*]Initial release
     [/list]
@@ -76,8 +128,12 @@
 <b>WARNING:</b> <color=#ff0000>This is a StationeersMods Plugin Mod. It requires Bepinex to be installed with the StationeersMods plugin.</color>
 See: https://github.com/jixxed/StationeersMods
 
-This mod adds a bunch of modes to the gas display consoles which coverts pretty much everything the atmospheric analyzer from the tablet gives you.
-There's 62 modes in total so have fun clicking!
+This mod adds a bunch of modes to the gas display consoles which covers pretty much everything the atmospheric analyzer from the tablet gives you.
+There's 63 modes in total so have fun clicking!
+You can use the quantity modifier to backtrack.
+You can also use the filter function of the console to target specific modes or at least get closer to the one you want.
+To use the mod's filter function you will need to hold Left Alt when clicking the confirm button in the filter input menu.
+The filter first checks if you inputted a tag, if it gets no match it tries to match your input to one of the display titles.
 
 <b>WARNING:</b> <color=#ff0000> This mod is incompatible with my KelvinConsole mod so make sure you disable/unsubscribe it if you have it installed.</color>
 
@@ -94,6 +150,7 @@ Exepected Behavior:
 List of modes:
   General Modes:
     * Pressure
+    * Precise Pressure
     * Temperature Celcius
     * Temperature Kelvin
     * Total moles

--- a/About/About.xml
+++ b/About/About.xml
@@ -13,10 +13,15 @@
 
     This mod adds a bunch of modes to the gas display consoles which covers pretty much everything the atmospheric analyzer from the tablet gives you.
     There's 63 modes in total so have fun clicking!
+
     You can use the quantity modifier to backtrack.
+
     You can also use the filter function of the console to target specific modes or at least get closer to the one you want.
     To use the mod's filter function you will need to hold Left Alt when clicking the confirm button in the filter input menu.
-    The filter first checks if you inputted a tag, if it gets no match it tries to match your input to one of the display titles.
+    The filter first checks if you inputted a tag listed below, if it gets no match it tries to match your input to one of the display titles and returns the first one found.
+    ex: inputting "LVOLP" will set the mode to "Liquid VOL Ratio".
+    ex: inputting "O2" will set the mode to "O2 Ratio".
+    ex: inputting "4" will set the mode to "Total Moles".
 
     Source: https://github.com/Vespinian/stationeers-mgdco
 
@@ -31,18 +36,17 @@
     [/list]
 
     List of tags and modes:
-    [list]
-    [*] "P"      - Vanilla Pressure
+    [olist]
     [*] "PP"     - Precise Pressure
     [*] "TC"     - Temperature Celcius
     [*] "TK"     - Temperature Kelvin
+    [*] "EC"     - Energy Convected
+    [*] "ER"     - Energy Radiated
+    [*] "EL"     - Energy Latent
     [*] "M",     - Total Moles
     [*] "GM"     - Gaseous Moles
     [*] "LM"     - Liquid Moles
     [*] "LV"     - Liquid Volume
-    [*] "EC"     - Energy Convected
-    [*] "ER"     - Energy Radiated
-    [*] "EL"     - Energy Latent
     [*] "O2P"    - O2 Ratio
     [*] "O2M"    - O2 Moles
     [*] "GO2P"   - Gaseous O2 Ratio
@@ -95,7 +99,8 @@
     [*] "LPH2OP" - Polluted Water Ratio
     [*] "LPH2OV" - Polluted Water Volum
     [*] "LPH2OM" - Polluted Water Moles
-    [/list]
+    [*] "P"      - Vanilla Pressure
+    [/olist]
 
   </Description>
   <!-- Ingame Description using TMP tags for Workshop menu -->
@@ -130,10 +135,14 @@ See: https://github.com/jixxed/StationeersMods
 
 This mod adds a bunch of modes to the gas display consoles which covers pretty much everything the atmospheric analyzer from the tablet gives you.
 There's 63 modes in total so have fun clicking!
+
 You can use the quantity modifier to backtrack.
+
 You can also use the filter function of the console to target specific modes or at least get closer to the one you want.
 To use the mod's filter function you will need to hold Left Alt when clicking the confirm button in the filter input menu.
-The filter first checks if you inputted a tag, if it gets no match it tries to match your input to one of the display titles.
+The filter first checks if you inputted a tag listed below, if it gets no match it tries to match your input to one of the display titles and returns the first one found.
+ex: inputting "LVOLP" will set the mode to "Liquid VOL Ratio".
+ex: inputting "O2" will set the mode to "O2 Ratio".
 
 <b>WARNING:</b> <color=#ff0000> This mod is incompatible with my KelvinConsole mod so make sure you disable/unsubscribe it if you have it installed.</color>
 

--- a/MGDCOPatchHelper.cs
+++ b/MGDCOPatchHelper.cs
@@ -8,7 +8,7 @@ namespace MoreGasDisplayConsoleOptions
 	{
 		public enum PatchGasDisplayMode
 		{
-			Pressure = 0,
+			PrecisePressure = 0,
 			Temperature,
 			TemperatureKelvin,
 			EnergyConvected,
@@ -77,6 +77,8 @@ namespace MoreGasDisplayConsoleOptions
 			RatioPollutedH2O,
 			QuantityPollutedH2O,
 			VolumePollutedH2O,
+			// Vanilla behavior
+			Pressure,
 
 			TotalDisplays,
 		}
@@ -93,9 +95,10 @@ namespace MoreGasDisplayConsoleOptions
 		// DisplayTitle , DisplayUnits, ToggleModeButtonText, Gas type, Patch Type, Combine liquid and gas for ratio and quantity data types
 		public static readonly Dictionary<int, (string tag, string displayName, string unit, string displayModeButton, Chemistry.GasType? gasType, PatchDataType dataType, bool combined)> GasData
 			= new Dictionary<int, (string, string, string, string, Chemistry.GasType?, PatchDataType, bool)> {
-			{(int)PatchGasDisplayMode.Pressure,            ("P", "PRESSURE",            "Pa",  "Mode: <b>Pressure</b>",             null, PatchDataType.Pressure, false)},
-			{(int)PatchGasDisplayMode.Temperature,         ("TC", "TEMPERATURE",         "°C",  "Mode: <b>Temperature (°C)</b>",     null, PatchDataType.Temperature, false)},
-			{(int)PatchGasDisplayMode.TemperatureKelvin,   ("TK", "TEMPERATURE",         "K",   "Mode: <b>Temperature (K)</b>",      null, PatchDataType.Temperature, false)},
+			{(int)PatchGasDisplayMode.Pressure,            ("P", "PRESSURE",            "Pa",  "Mode: <b>Pressure</b>",     null, PatchDataType.Pressure, false)},
+			{(int)PatchGasDisplayMode.PrecisePressure,     ("PP", "PRESSURE",            "Pa",  "Mode: <b>Precise Pressure</b>",             null, PatchDataType.Pressure, false)},
+			{(int)PatchGasDisplayMode.Temperature,         ("TC", "TEMPERATURE",         "°C",  "Mode: <b>Temperature (°C)</b>",    null, PatchDataType.Temperature, false)},
+			{(int)PatchGasDisplayMode.TemperatureKelvin,   ("TK", "TEMPERATURE",         "K",   "Mode: <b>Temperature (K)</b>",     null, PatchDataType.Temperature, false)},
 			{(int)PatchGasDisplayMode.TotalMoles,          ("M", "TOTAL MOLES",         "mol", "Mode: <b>Total (mol)</b>",          null, PatchDataType.Quantity, true)},
 			{(int)PatchGasDisplayMode.TotalGaseousMoles,   ("GM", "TOTAL GASEOUS",       "mol", "Mode: <b>Total Gas (mol)</b>",      null, PatchDataType.Quantity, false)},
 			{(int)PatchGasDisplayMode.TotalLiquidMoles,    ("LM", "TOTAL LIQUID",        "mol", "Mode: <b>Total Liquid (mol)</b>",   Chemistry.GasType.Undefined, PatchDataType.Quantity, false)},
@@ -349,7 +352,7 @@ namespace MoreGasDisplayConsoleOptions
 			return energy;
 		}
 
-		public static (string, string) FormatSIUnits(float value, string unit)
+		public static string FormatSIUnits(float value, string unit)
 		{
 			string formatedNumber = "";
 			string formatedUnits = unit;
@@ -418,7 +421,7 @@ namespace MoreGasDisplayConsoleOptions
 				formatedNumber = string.Format("{0:0}", (object)value);
 			}
 
-			return (formatedNumber, formatedUnits);
+			return formatedNumber + "|" + formatedUnits;
 		}
 
 	}

--- a/MGDCOPatchHelper.cs
+++ b/MGDCOPatchHelper.cs
@@ -91,101 +91,101 @@ namespace MoreGasDisplayConsoleOptions
 		}
 
 		// DisplayTitle , DisplayUnits, ToggleModeButtonText, Gas type, Patch Type, Combine liquid and gas for ratio and quantity data types
-		public static readonly Dictionary<int, (string, string, string, Chemistry.GasType?, PatchDataType, bool)> GasData
-			= new Dictionary<int, (string, string, string, Chemistry.GasType?, PatchDataType, bool)> {
-			{(int)PatchGasDisplayMode.Pressure,            ("PRESSURE",            "Pa",  "Mode: <b>Pressure</b>",             null, PatchDataType.Pressure, false)},
-			{(int)PatchGasDisplayMode.Temperature,         ("TEMPERATURE",         "°C",  "Mode: <b>Temperature (°C)</b>",     null, PatchDataType.Temperature, false)},
-			{(int)PatchGasDisplayMode.TemperatureKelvin,   ("TEMPERATURE",         "K",   "Mode: <b>Temperature (K)</b>",      null, PatchDataType.Temperature, false)},
-			{(int)PatchGasDisplayMode.TotalMoles,          ("TOTAL MOLES",         "mol", "Mode: <b>Total (mol)</b>",          null, PatchDataType.Quantity, true)},
-			{(int)PatchGasDisplayMode.TotalGaseousMoles,   ("TOTAL GASEOUS",       "mol", "Mode: <b>Total Gas (mol)</b>",      null, PatchDataType.Quantity, false)},
-			{(int)PatchGasDisplayMode.TotalLiquidMoles,    ("TOTAL LIQUID",        "mol", "Mode: <b>Total Liquid (mol)</b>",   Chemistry.GasType.Undefined, PatchDataType.Quantity, false)},
-			{(int)PatchGasDisplayMode.TotalLiquidVolume,   ("TOTAL LIQUID",        "L",   "Mode: <b>Total Liquid (L)</b>",     null, PatchDataType.Volume, false)},
-			{(int)PatchGasDisplayMode.EnergyConvected,     ("CONVECTED",           "J",   "Mode: <b>Convected (J)</b>",        null, PatchDataType.Energy, false)},
-			{(int)PatchGasDisplayMode.EnergyRadiated,      ("RADIATED",            "J",   "Mode: <b>Radiated (J)</b>",         null, PatchDataType.Energy, false)},
-			{(int)PatchGasDisplayMode.EnergyLatent,        ("LATENT",              "J",   "Mode: <b>Latent (J)</b>",           null, PatchDataType.Energy, false)},
+		public static readonly Dictionary<int, (string tag, string displayName, string unit, string displayModeButton, Chemistry.GasType? gasType, PatchDataType dataType, bool combined)> GasData
+			= new Dictionary<int, (string, string, string, string, Chemistry.GasType?, PatchDataType, bool)> {
+			{(int)PatchGasDisplayMode.Pressure,            ("P", "PRESSURE",            "Pa",  "Mode: <b>Pressure</b>",             null, PatchDataType.Pressure, false)},
+			{(int)PatchGasDisplayMode.Temperature,         ("TC", "TEMPERATURE",         "°C",  "Mode: <b>Temperature (°C)</b>",     null, PatchDataType.Temperature, false)},
+			{(int)PatchGasDisplayMode.TemperatureKelvin,   ("TK", "TEMPERATURE",         "K",   "Mode: <b>Temperature (K)</b>",      null, PatchDataType.Temperature, false)},
+			{(int)PatchGasDisplayMode.TotalMoles,          ("M", "TOTAL MOLES",         "mol", "Mode: <b>Total (mol)</b>",          null, PatchDataType.Quantity, true)},
+			{(int)PatchGasDisplayMode.TotalGaseousMoles,   ("GM", "TOTAL GASEOUS",       "mol", "Mode: <b>Total Gas (mol)</b>",      null, PatchDataType.Quantity, false)},
+			{(int)PatchGasDisplayMode.TotalLiquidMoles,    ("LM", "TOTAL LIQUID",        "mol", "Mode: <b>Total Liquid (mol)</b>",   Chemistry.GasType.Undefined, PatchDataType.Quantity, false)},
+			{(int)PatchGasDisplayMode.TotalLiquidVolume,   ("LV", "TOTAL LIQUID",        "L",   "Mode: <b>Total Liquid (L)</b>",     null, PatchDataType.Volume, false)},
+			{(int)PatchGasDisplayMode.EnergyConvected,     ("EC", "CONVECTED",           "J",   "Mode: <b>Convected (J)</b>",        null, PatchDataType.Energy, false)},
+			{(int)PatchGasDisplayMode.EnergyRadiated,      ("ER", "RADIATED",            "J",   "Mode: <b>Radiated (J)</b>",         null, PatchDataType.Energy, false)},
+			{(int)PatchGasDisplayMode.EnergyLatent,        ("EL", "LATENT",              "J",   "Mode: <b>Latent (J)</b>",           null, PatchDataType.Energy, false)},
 			// O2
-			{(int)PatchGasDisplayMode.RatioO2,             ("O2",          "%",    "Mode: <b>O₂ (%)</b>",            Chemistry.GasType.Oxygen, PatchDataType.Ratio, true)},
-			{(int)PatchGasDisplayMode.QuantityO2,          ("O2",          "mol",  "Mode: <b>O₂ (mol)</b>",          Chemistry.GasType.Oxygen, PatchDataType.Quantity, true)},
-			{(int)PatchGasDisplayMode.RatioGaseousO2,      ("GASEOUS O2",  "%",    "Mode: <b>Gaseous O₂ (%)</b>",    Chemistry.GasType.Oxygen, PatchDataType.Ratio, false)},
-			{(int)PatchGasDisplayMode.QuantityGaseousO2,   ("GASEOUS O2",  "mol",  "Mode: <b>Gaseous O₂ (mol)</b>",  Chemistry.GasType.Oxygen, PatchDataType.Quantity, false)},
-			{(int)PatchGasDisplayMode.RatioLiquidO2,       ("LIQUID O2",   "%",    "Mode: <b>Liquid O₂ (%)</b>",     Chemistry.GasType.LiquidOxygen, PatchDataType.Ratio, false)},
-			{(int)PatchGasDisplayMode.VolumeLiquidO2,      ("LIQUID O2",   "L",    "Mode: <b>Liquid O₂ (L)</b>",     Chemistry.GasType.LiquidOxygen, PatchDataType.Volume, false)},
-			{(int)PatchGasDisplayMode.QuantityLiquidO2,    ("LIQUID O2",   "mol",  "Mode: <b>Liquid O₂ (mol)</b>",   Chemistry.GasType.LiquidOxygen, PatchDataType.Quantity, false)},
+			{(int)PatchGasDisplayMode.RatioO2,             ("O2P", "O2",          "%",    "Mode: <b>O₂ (%)</b>",            Chemistry.GasType.Oxygen, PatchDataType.Ratio, true)},
+			{(int)PatchGasDisplayMode.QuantityO2,          ("O2M", "O2",          "mol",  "Mode: <b>O₂ (mol)</b>",          Chemistry.GasType.Oxygen, PatchDataType.Quantity, true)},
+			{(int)PatchGasDisplayMode.RatioGaseousO2,      ("GO2P", "GASEOUS O2",  "%",    "Mode: <b>Gaseous O₂ (%)</b>",    Chemistry.GasType.Oxygen, PatchDataType.Ratio, false)},
+			{(int)PatchGasDisplayMode.QuantityGaseousO2,   ("GO2M", "GASEOUS O2",  "mol",  "Mode: <b>Gaseous O₂ (mol)</b>",  Chemistry.GasType.Oxygen, PatchDataType.Quantity, false)},
+			{(int)PatchGasDisplayMode.RatioLiquidO2,       ("LO2P", "LIQUID O2",   "%",    "Mode: <b>Liquid O₂ (%)</b>",     Chemistry.GasType.LiquidOxygen, PatchDataType.Ratio, false)},
+			{(int)PatchGasDisplayMode.VolumeLiquidO2,      ("LO2V", "LIQUID O2",   "L",    "Mode: <b>Liquid O₂ (L)</b>",     Chemistry.GasType.LiquidOxygen, PatchDataType.Volume, false)},
+			{(int)PatchGasDisplayMode.QuantityLiquidO2,    ("LO2M", "LIQUID O2",   "mol",  "Mode: <b>Liquid O₂ (mol)</b>",   Chemistry.GasType.LiquidOxygen, PatchDataType.Quantity, false)},
 			// Nitrogen
-			{(int)PatchGasDisplayMode.RatioN,              ("N",          "%",    "Mode: <b>N (%)</b>",           Chemistry.GasType.Nitrogen, PatchDataType.Ratio, true)},
-			{(int)PatchGasDisplayMode.QuantityN,           ("N",          "mol",  "Mode: <b>N (mol)</b>",         Chemistry.GasType.Nitrogen, PatchDataType.Quantity, true)},
-			{(int)PatchGasDisplayMode.RatioGaseousN,       ("GASEOUS N",  "%",    "Mode: <b>Gaseous N (%)</b>",   Chemistry.GasType.Nitrogen, PatchDataType.Ratio, false)},
-			{(int)PatchGasDisplayMode.QuantityGaseousN,    ("GASEOUS N",  "mol",  "Mode: <b>Gaseous N (mol)</b>", Chemistry.GasType.Nitrogen, PatchDataType.Quantity, false)},
-			{(int)PatchGasDisplayMode.RatioLiquidN,        ("LIQUID N",   "%",    "Mode: <b>Liquid N (%)</b>",    Chemistry.GasType.LiquidNitrogen, PatchDataType.Ratio, false)},
-			{(int)PatchGasDisplayMode.VolumeLiquidN,       ("LIQUID N",   "L",    "Mode: <b>Liquid N (L)</b>",    Chemistry.GasType.LiquidNitrogen, PatchDataType.Volume, false)},
-			{(int)PatchGasDisplayMode.QuantityLiquidN,     ("LIQUID N",   "mol",  "Mode: <b>Liquid N (mol)</b>",  Chemistry.GasType.LiquidNitrogen, PatchDataType.Quantity, false)},
+			{(int)PatchGasDisplayMode.RatioN,              ("NP", "N",          "%",    "Mode: <b>N (%)</b>",           Chemistry.GasType.Nitrogen, PatchDataType.Ratio, true)},
+			{(int)PatchGasDisplayMode.QuantityN,           ("NM", "N",          "mol",  "Mode: <b>N (mol)</b>",         Chemistry.GasType.Nitrogen, PatchDataType.Quantity, true)},
+			{(int)PatchGasDisplayMode.RatioGaseousN,       ("NP", "GASEOUS N",  "%",    "Mode: <b>Gaseous N (%)</b>",   Chemistry.GasType.Nitrogen, PatchDataType.Ratio, false)},
+			{(int)PatchGasDisplayMode.QuantityGaseousN,    ("GNM", "GASEOUS N",  "mol",  "Mode: <b>Gaseous N (mol)</b>", Chemistry.GasType.Nitrogen, PatchDataType.Quantity, false)},
+			{(int)PatchGasDisplayMode.RatioLiquidN,        ("LNP", "LIQUID N",   "%",    "Mode: <b>Liquid N (%)</b>",    Chemistry.GasType.LiquidNitrogen, PatchDataType.Ratio, false)},
+			{(int)PatchGasDisplayMode.VolumeLiquidN,       ("LNV", "LIQUID N",   "L",    "Mode: <b>Liquid N (L)</b>",    Chemistry.GasType.LiquidNitrogen, PatchDataType.Volume, false)},
+			{(int)PatchGasDisplayMode.QuantityLiquidN,     ("LNM", "LIQUID N",   "mol",  "Mode: <b>Liquid N (mol)</b>",  Chemistry.GasType.LiquidNitrogen, PatchDataType.Quantity, false)},
 			// CO2
-			{(int)PatchGasDisplayMode.RatioCO2,            ("CO2",          "%",    "Mode: <b>CO₂ (%)</b>",              Chemistry.GasType.CarbonDioxide, PatchDataType.Ratio, true)},
-			{(int)PatchGasDisplayMode.QuantityCO2,         ("CO2",          "mol",  "Mode: <b>CO₂ (mol)</b>",            Chemistry.GasType.CarbonDioxide, PatchDataType.Quantity, true)},
-			{(int)PatchGasDisplayMode.RatioGaseousCO2,     ("GASEOUS CO2",  "%",    "Mode: <b>Gaseous CO₂ (%)</b>",      Chemistry.GasType.CarbonDioxide, PatchDataType.Ratio, false)},
-			{(int)PatchGasDisplayMode.QuantityGaseousCO2,  ("GASEOUS CO2",  "mol",  "Mode: <b>Gaseous CO₂ (mol)</b>",    Chemistry.GasType.CarbonDioxide, PatchDataType.Quantity, false)},
-			{(int)PatchGasDisplayMode.RatioLiquidCO2,      ("LIQUID CO2",   "%",    "Mode: <b>Liquid CO₂ (%)</b>",       Chemistry.GasType.LiquidCarbonDioxide, PatchDataType.Ratio, false)},
-			{(int)PatchGasDisplayMode.VolumeLiquidCO2,     ("LIQUID CO2",   "L",    "Mode: <b>Liquid CO₂ (L)</b>",       Chemistry.GasType.LiquidCarbonDioxide, PatchDataType.Volume, false)},
-			{(int)PatchGasDisplayMode.QuantityLiquidCO2,   ("LIQUID CO2",   "mol",  "Mode: <b>Liquid CO₂ (mol)</b>",     Chemistry.GasType.LiquidCarbonDioxide, PatchDataType.Quantity, false)},
+			{(int)PatchGasDisplayMode.RatioCO2,            ("CO2P", "CO2",          "%",    "Mode: <b>CO₂ (%)</b>",              Chemistry.GasType.CarbonDioxide, PatchDataType.Ratio, true)},
+			{(int)PatchGasDisplayMode.QuantityCO2,         ("CO2M", "CO2",          "mol",  "Mode: <b>CO₂ (mol)</b>",            Chemistry.GasType.CarbonDioxide, PatchDataType.Quantity, true)},
+			{(int)PatchGasDisplayMode.RatioGaseousCO2,     ("GCO2P", "GASEOUS CO2",  "%",    "Mode: <b>Gaseous CO₂ (%)</b>",      Chemistry.GasType.CarbonDioxide, PatchDataType.Ratio, false)},
+			{(int)PatchGasDisplayMode.QuantityGaseousCO2,  ("GCO2M", "GASEOUS CO2",  "mol",  "Mode: <b>Gaseous CO₂ (mol)</b>",    Chemistry.GasType.CarbonDioxide, PatchDataType.Quantity, false)},
+			{(int)PatchGasDisplayMode.RatioLiquidCO2,      ("LCO2P", "LIQUID CO2",   "%",    "Mode: <b>Liquid CO₂ (%)</b>",       Chemistry.GasType.LiquidCarbonDioxide, PatchDataType.Ratio, false)},
+			{(int)PatchGasDisplayMode.VolumeLiquidCO2,     ("LCO2V", "LIQUID CO2",   "L",    "Mode: <b>Liquid CO₂ (L)</b>",       Chemistry.GasType.LiquidCarbonDioxide, PatchDataType.Volume, false)},
+			{(int)PatchGasDisplayMode.QuantityLiquidCO2,   ("LCO2M", "LIQUID CO2",   "mol",  "Mode: <b>Liquid CO₂ (mol)</b>",     Chemistry.GasType.LiquidCarbonDioxide, PatchDataType.Quantity, false)},
 			// Pol
-			{(int)PatchGasDisplayMode.RatioPol,            ("POL",          "%",    "Mode: <b>POL (%)</b>",              Chemistry.GasType.Pollutant, PatchDataType.Ratio, true)},
-			{(int)PatchGasDisplayMode.QuantityPol,         ("POL",          "mol",  "Mode: <b>POL (mol)</b>",            Chemistry.GasType.Pollutant, PatchDataType.Quantity, true)},
-			{(int)PatchGasDisplayMode.RatioGaseousPol,     ("GASEOUS POL",  "%",    "Mode: <b>Gaseous POL (%)</b>",      Chemistry.GasType.Pollutant, PatchDataType.Ratio, false)},
-			{(int)PatchGasDisplayMode.QuantityGaseousPol,  ("GASEOUS POL",  "mol",  "Mode: <b>Gaseous POL (mol)</b>",    Chemistry.GasType.Pollutant, PatchDataType.Quantity, false)},
-			{(int)PatchGasDisplayMode.RatioLiquidPol,      ("LIQUID POL",   "%",    "Mode: <b>Liquid POL (%)</b>",       Chemistry.GasType.LiquidPollutant, PatchDataType.Ratio, false)},
-			{(int)PatchGasDisplayMode.VolumeLiquidPol,     ("LIQUID POL",   "L",    "Mode: <b>Liquid POL (L)</b>",       Chemistry.GasType.LiquidPollutant, PatchDataType.Volume, false)},
-			{(int)PatchGasDisplayMode.QuantityLiquidPol,   ("LIQUID POL",   "mol",  "Mode: <b>Liquid POL (mol)</b>",     Chemistry.GasType.LiquidPollutant, PatchDataType.Quantity, false)},
+			{(int)PatchGasDisplayMode.RatioPol,            ("POLP", "POL",          "%",    "Mode: <b>POL (%)</b>",              Chemistry.GasType.Pollutant, PatchDataType.Ratio, true)},
+			{(int)PatchGasDisplayMode.QuantityPol,         ("POLM", "POL",          "mol",  "Mode: <b>POL (mol)</b>",            Chemistry.GasType.Pollutant, PatchDataType.Quantity, true)},
+			{(int)PatchGasDisplayMode.RatioGaseousPol,     ("GPOLP", "GASEOUS POL",  "%",    "Mode: <b>Gaseous POL (%)</b>",      Chemistry.GasType.Pollutant, PatchDataType.Ratio, false)},
+			{(int)PatchGasDisplayMode.QuantityGaseousPol,  ("GPOLM", "GASEOUS POL",  "mol",  "Mode: <b>Gaseous POL (mol)</b>",    Chemistry.GasType.Pollutant, PatchDataType.Quantity, false)},
+			{(int)PatchGasDisplayMode.RatioLiquidPol,      ("LPOLP", "LIQUID POL",   "%",    "Mode: <b>Liquid POL (%)</b>",       Chemistry.GasType.LiquidPollutant, PatchDataType.Ratio, false)},
+			{(int)PatchGasDisplayMode.VolumeLiquidPol,     ("LPOLV", "LIQUID POL",   "L",    "Mode: <b>Liquid POL (L)</b>",       Chemistry.GasType.LiquidPollutant, PatchDataType.Volume, false)},
+			{(int)PatchGasDisplayMode.QuantityLiquidPol,   ("LPOLM", "LIQUID POL",   "mol",  "Mode: <b>Liquid POL (mol)</b>",     Chemistry.GasType.LiquidPollutant, PatchDataType.Quantity, false)},
 			// Vol
-			{(int)PatchGasDisplayMode.RatioVol,            ("VOL",          "%",    "Mode: <b>VOL (%)</b>",              Chemistry.GasType.Volatiles, PatchDataType.Ratio, true)},
-			{(int)PatchGasDisplayMode.QuantityVol,         ("VOL",          "mol",  "Mode: <b>VOL (mol)</b>",            Chemistry.GasType.Volatiles, PatchDataType.Quantity, true)},
-			{(int)PatchGasDisplayMode.RatioGaseousVol,     ("GASEOUS VOL",  "%",    "Mode: <b>Gaseous VOL (%)</b>",      Chemistry.GasType.Volatiles, PatchDataType.Ratio, false)},
-			{(int)PatchGasDisplayMode.QuantityGaseousVol,  ("GASEOUS VOL",  "mol",  "Mode: <b>Gaseous VOL (mol)</b>",    Chemistry.GasType.Volatiles, PatchDataType.Quantity, false)},
-			{(int)PatchGasDisplayMode.RatioLiquidVol,      ("LIQUID VOL",   "%",    "Mode: <b>Liquid VOL (%)</b>",       Chemistry.GasType.LiquidVolatiles, PatchDataType.Ratio, false)},
-			{(int)PatchGasDisplayMode.VolumeLiquidVol,     ("LIQUID VOL",   "L",    "Mode: <b>Liquid VOL (L)</b>",       Chemistry.GasType.LiquidVolatiles, PatchDataType.Volume, false)},
-			{(int)PatchGasDisplayMode.QuantityLiquidVol,   ("LIQUID VOL",   "mol",  "Mode: <b>Liquid VOL (mol)</b>",     Chemistry.GasType.LiquidVolatiles, PatchDataType.Quantity, false)},
+			{(int)PatchGasDisplayMode.RatioVol,            ("VOLP", "VOL",          "%",    "Mode: <b>VOL (%)</b>",              Chemistry.GasType.Volatiles, PatchDataType.Ratio, true)},
+			{(int)PatchGasDisplayMode.QuantityVol,         ("VOLM", "VOL",          "mol",  "Mode: <b>VOL (mol)</b>",            Chemistry.GasType.Volatiles, PatchDataType.Quantity, true)},
+			{(int)PatchGasDisplayMode.RatioGaseousVol,     ("GVOLP", "GASEOUS VOL",  "%",    "Mode: <b>Gaseous VOL (%)</b>",      Chemistry.GasType.Volatiles, PatchDataType.Ratio, false)},
+			{(int)PatchGasDisplayMode.QuantityGaseousVol,  ("GVOLM", "GASEOUS VOL",  "mol",  "Mode: <b>Gaseous VOL (mol)</b>",    Chemistry.GasType.Volatiles, PatchDataType.Quantity, false)},
+			{(int)PatchGasDisplayMode.RatioLiquidVol,      ("LVOLP", "LIQUID VOL",   "%",    "Mode: <b>Liquid VOL (%)</b>",       Chemistry.GasType.LiquidVolatiles, PatchDataType.Ratio, false)},
+			{(int)PatchGasDisplayMode.VolumeLiquidVol,     ("LVOLV", "LIQUID VOL",   "L",    "Mode: <b>Liquid VOL (L)</b>",       Chemistry.GasType.LiquidVolatiles, PatchDataType.Volume, false)},
+			{(int)PatchGasDisplayMode.QuantityLiquidVol,   ("LVOLM", "LIQUID VOL",   "mol",  "Mode: <b>Liquid VOL (mol)</b>",     Chemistry.GasType.LiquidVolatiles, PatchDataType.Quantity, false)},
 			// N2O
-			{(int)PatchGasDisplayMode.RatioN2O,            ("N2O",          "%",    "Mode: <b>N₂O (%)</b>",              Chemistry.GasType.NitrousOxide, PatchDataType.Ratio, true)},
-			{(int)PatchGasDisplayMode.QuantityN2O,         ("N2O",          "mol",  "Mode: <b>N₂O (mol)</b>",            Chemistry.GasType.NitrousOxide, PatchDataType.Quantity, true)},
-			{(int)PatchGasDisplayMode.RatioGaseousN2O,     ("GASEOUS N2O",  "%",    "Mode: <b>Gaseous N₂O (%)</b>",      Chemistry.GasType.NitrousOxide, PatchDataType.Ratio, false)},
-			{(int)PatchGasDisplayMode.QuantityGaseousN2O,  ("GASEOUS N2O",  "mol",  "Mode: <b>Gaseous N₂O (mol)</b>",    Chemistry.GasType.NitrousOxide, PatchDataType.Quantity, false)},
-			{(int)PatchGasDisplayMode.RatioLiquidN2O,      ("LIQUID N2O",   "%",    "Mode: <b>Liquid N₂O (%)</b>",       Chemistry.GasType.LiquidNitrousOxide, PatchDataType.Ratio, false)},
-			{(int)PatchGasDisplayMode.VolumeLiquidN2O,     ("LIQUID N2O",   "L",    "Mode: <b>Liquid N₂O (L)</b>",       Chemistry.GasType.LiquidNitrousOxide, PatchDataType.Volume, false)},
-			{(int)PatchGasDisplayMode.QuantityLiquidN2O,   ("LIQUID N2O",   "mol",  "Mode: <b>Liquid N₂O (mol)</b>",     Chemistry.GasType.LiquidNitrousOxide, PatchDataType.Quantity, false)},
+			{(int)PatchGasDisplayMode.RatioN2O,            ("N2OP", "N2O",          "%",    "Mode: <b>N₂O (%)</b>",              Chemistry.GasType.NitrousOxide, PatchDataType.Ratio, true)},
+			{(int)PatchGasDisplayMode.QuantityN2O,         ("N2OM", "N2O",          "mol",  "Mode: <b>N₂O (mol)</b>",            Chemistry.GasType.NitrousOxide, PatchDataType.Quantity, true)},
+			{(int)PatchGasDisplayMode.RatioGaseousN2O,     ("GN2OP", "GASEOUS N2O",  "%",    "Mode: <b>Gaseous N₂O (%)</b>",      Chemistry.GasType.NitrousOxide, PatchDataType.Ratio, false)},
+			{(int)PatchGasDisplayMode.QuantityGaseousN2O,  ("GN2OM", "GASEOUS N2O",  "mol",  "Mode: <b>Gaseous N₂O (mol)</b>",    Chemistry.GasType.NitrousOxide, PatchDataType.Quantity, false)},
+			{(int)PatchGasDisplayMode.RatioLiquidN2O,      ("LN2OP", "LIQUID N2O",   "%",    "Mode: <b>Liquid N₂O (%)</b>",       Chemistry.GasType.LiquidNitrousOxide, PatchDataType.Ratio, false)},
+			{(int)PatchGasDisplayMode.VolumeLiquidN2O,     ("LN2OV", "LIQUID N2O",   "L",    "Mode: <b>Liquid N₂O (L)</b>",       Chemistry.GasType.LiquidNitrousOxide, PatchDataType.Volume, false)},
+			{(int)PatchGasDisplayMode.QuantityLiquidN2O,   ("LN2OM", "LIQUID N2O",   "mol",  "Mode: <b>Liquid N₂O (mol)</b>",     Chemistry.GasType.LiquidNitrousOxide, PatchDataType.Quantity, false)},
 			// H2O
-			{(int)PatchGasDisplayMode.RatioH2O,            ("H2O",            "%",    "Mode: <b>H₂O (%)</b>",              Chemistry.GasType.Steam, PatchDataType.Ratio, true)},
-			{(int)PatchGasDisplayMode.QuantityH2O,         ("H2O",            "mol",  "Mode: <b>H₂O (mol)</b>",            Chemistry.GasType.Steam, PatchDataType.Quantity, true)},
-			{(int)PatchGasDisplayMode.RatioSteam,          ("STEAM",          "%",    "Mode: <b>Steam (%)</b>",            Chemistry.GasType.Steam, PatchDataType.Ratio, false)},
-			{(int)PatchGasDisplayMode.QuantitySteam,       ("STEAM",          "mol",  "Mode: <b>Steam (mol)</b>",          Chemistry.GasType.Steam, PatchDataType.Quantity, false)},
-			{(int)PatchGasDisplayMode.RatioWater,          ("WATER",          "%",    "Mode: <b>Water (%)</b>",            Chemistry.GasType.Water, PatchDataType.Ratio, false)},
-			{(int)PatchGasDisplayMode.VolumeWater,         ("WATER",          "L",    "Mode: <b>Water (L)</b>",            Chemistry.GasType.Water, PatchDataType.Volume, false)},
-			{(int)PatchGasDisplayMode.QuantityWater,       ("WATER",          "mol",  "Mode: <b>Water (mol)</b>",          Chemistry.GasType.Water, PatchDataType.Quantity, false)},
-			{(int)PatchGasDisplayMode.RatioPollutedH2O,    ("POLLUTED WATER", "%",    "Mode: <b>Polluted Water (%)</b>",   Chemistry.GasType.PollutedWater, PatchDataType.Ratio, false)},
-			{(int)PatchGasDisplayMode.VolumePollutedH2O,   ("POLLUTED WATER", "L",    "Mode: <b>Polluted Water (L)</b>",   Chemistry.GasType.PollutedWater, PatchDataType.Volume, false)},
-			{(int)PatchGasDisplayMode.QuantityPollutedH2O, ("POLLUTED WATER", "mol",  "Mode: <b>Polluted Water (mol)</b>", Chemistry.GasType.PollutedWater, PatchDataType.Quantity, false)},
+			{(int)PatchGasDisplayMode.RatioH2O,            ("H2OP ", "H2O",            "%",    "Mode: <b>H₂O (%)</b>",              Chemistry.GasType.Steam, PatchDataType.Ratio, true)},
+			{(int)PatchGasDisplayMode.QuantityH2O,         ("H2OM ", "H2O",            "mol",  "Mode: <b>H₂O (mol)</b>",            Chemistry.GasType.Steam, PatchDataType.Quantity, true)},
+			{(int)PatchGasDisplayMode.RatioSteam,          ("GH2OP", "STEAM",          "%",    "Mode: <b>Steam (%)</b>",            Chemistry.GasType.Steam, PatchDataType.Ratio, false)},
+			{(int)PatchGasDisplayMode.QuantitySteam,       ("GH2OM", "STEAM",          "mol",  "Mode: <b>Steam (mol)</b>",          Chemistry.GasType.Steam, PatchDataType.Quantity, false)},
+			{(int)PatchGasDisplayMode.RatioWater,          ("LH2OP", "WATER",          "%",    "Mode: <b>Water (%)</b>",            Chemistry.GasType.Water, PatchDataType.Ratio, false)},
+			{(int)PatchGasDisplayMode.VolumeWater,         ("LH2OV", "WATER",          "L",    "Mode: <b>Water (L)</b>",            Chemistry.GasType.Water, PatchDataType.Volume, false)},
+			{(int)PatchGasDisplayMode.QuantityWater,       ("LH2OM", "WATER",          "mol",  "Mode: <b>Water (mol)</b>",          Chemistry.GasType.Water, PatchDataType.Quantity, false)},
+			{(int)PatchGasDisplayMode.RatioPollutedH2O,    ("LPH2OP", "POLLUTED WATER", "%",    "Mode: <b>Polluted Water (%)</b>",   Chemistry.GasType.PollutedWater, PatchDataType.Ratio, false)},
+			{(int)PatchGasDisplayMode.VolumePollutedH2O,   ("LPH2OV", "POLLUTED WATER", "L",    "Mode: <b>Polluted Water (L)</b>",   Chemistry.GasType.PollutedWater, PatchDataType.Volume, false)},
+			{(int)PatchGasDisplayMode.QuantityPollutedH2O, ("LPH2OM", "POLLUTED WATER", "mol",  "Mode: <b>Polluted Water (mol)</b>", Chemistry.GasType.PollutedWater, PatchDataType.Quantity, false)},
 		};
 
 		public static string getGasDisplayModeTitle(int index) {
-			return GasData[index].Item1;
+			return GasData[index].Item2;
 		}
 		public static string getDisplayModeUnits(int index)
 		{
-			return GasData[index].Item2;
+			return GasData[index].Item3;
 		}
 		public static string getGasDisplayModeButtonName(int index)
 		{
-			return GasData[index].Item3;
+			return GasData[index].Item4;
 		}
 		public static Chemistry.GasType? getGasDisplayModeGas(int index)
 		{
-			return GasData[index].Item4;
+			return GasData[index].Item5;
 		}
 		public static PatchDataType getGasDisplayModePatchDataType(int index)
 		{
-			return GasData[index].Item5;
+			return GasData[index].Item6;
 		}
 		public static bool getGasDisplayModeCombinedFlag(int index)
 		{
-			return GasData[index].Item6;
+			return GasData[index].Item7;
 		}
 
 		public static float GetGasSensorQuantity(Chemistry.GasType? gasType, Atmosphere atmosphere, bool combined)

--- a/MGDCOPatches.cs
+++ b/MGDCOPatches.cs
@@ -52,9 +52,11 @@ namespace MoreGasDisplayConsoleOptions
 	{
 		static bool Prefix(string value, string value2, Circuitboard __instance)
 		{
-			if (__instance is GasDisplay && !string.IsNullOrEmpty(value) && value[0] == '/')
+			//if (__instance is GasDisplay && !string.IsNullOrEmpty(value) && value[0] == '/') // if using "/" as mode filter
+			if (__instance is GasDisplay && !string.IsNullOrEmpty(value) && KeyManager.GetButton(KeyCode.LeftAlt))
 			{
-				string tag = value.Substring(1);
+				//string tag = value.Substring(1); // if using "/" as mode filter
+				string tag = value;
 				int index = 0;
 				if (int.TryParse(tag, out index))
 				{
@@ -83,6 +85,7 @@ namespace MoreGasDisplayConsoleOptions
 						return false;
 					}
 				}
+				return false;
 			}
 			return true;
 		}

--- a/MGDCOPatches.cs
+++ b/MGDCOPatches.cs
@@ -60,8 +60,8 @@ namespace MoreGasDisplayConsoleOptions
 				int index = 0;
 				if (int.TryParse(tag, out index))
 				{
-					if (index >= 0 && index < (int)MGDCOPatchHelper.PatchGasDisplayMode.TotalDisplays)
-						__instance.SetFlag(index);
+					if (index >= 1 && index <= (int)MGDCOPatchHelper.PatchGasDisplayMode.TotalDisplays)
+						__instance.SetFlag(index-1);
 					return false;
 				}
 				else {

--- a/MoreGasDisplayConsoleOptions.info
+++ b/MoreGasDisplayConsoleOptions.info
@@ -2,7 +2,7 @@
     "_name": "MoreGasDisplayConsoleOptions",
     "_author": "Vespinian",
     "_description": "Adds more modes to the gas display console.",
-    "_version": "1.1",
+    "_version": "1.2",
     "_unityVersion": "2021.2.13f1",
     "_platforms": 1,
     "_content": 4,

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+﻿Remember to update the MoreGasDisplayConsoleOptions.VS.props with your Stationeers directory!
+Also this repo auto copies the built files to the user mod folder so be aware of that.


### PR DESCRIPTION
* Can now use the quantity modifier key to cycle through mods backwards
* Can now use the filter function to target certain modes when holding left alt when clicking the Confirm button in the filter input menu.
* Added back old vanilla pressure format function to as Pressure, the new formatting is now known as Precise Pressure.
* Reworked how the display text is updated since it would throw errors in it's old form when you removed connected device. it's now updated in a post patch of UpdateEachFrame where it used to be before my patches. This seems to fix the problems that I was seeing. Also had to bundle the units with the label and split them back in this function. I tried using the lastindex field but it wouldn't behave correctly.